### PR TITLE
check first if the element is available in LO

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -1,7 +1,12 @@
 module.exports = (Franz) => {
   function getUnreadConversations() {
     let unreadConversations = 0;
-    unreadConversations = parseInt(document.querySelector('#unread-conversations').innerHTML, 10);
+    let unreadConvElement = document.querySelector('#unread-conversations');
+    
+    // on logged-out, we do not have such an element, check first!
+    if (unreadConvElement !== null && unreadConvElement.innerHTM) {
+      unreadConversations = parseInt(unreadConvElement.innerHTML, 10);
+    }
 
     Franz.setBadge(unreadConversations);
   }

--- a/webview.js
+++ b/webview.js
@@ -1,10 +1,10 @@
 module.exports = (Franz) => {
   function getUnreadConversations() {
     let unreadConversations = 0;
-    let unreadConvElement = document.querySelector('#unread-conversations');
+    const unreadConvElement = document.querySelector('#unread-conversations');
     
     // on logged-out, we do not have such an element, check first!
-    if (unreadConvElement !== null && unreadConvElement.innerHTM) {
+    if (unreadConvElement !== null && unreadConvElement.innerHTML) {
       unreadConversations = parseInt(unreadConvElement.innerHTML, 10);
     }
 


### PR DESCRIPTION
In LO, we do not have the element in question and hence, need to check first if the element is existing. This produces less noise in the console but does not change anything for the user.